### PR TITLE
Fixed xrsession markup

### DIFF
--- a/webxr-device-api/xrsession.md
+++ b/webxr-device-api/xrsession.md
@@ -77,8 +77,6 @@ The **`XRSession`** interface of the WebXR API provides the means to interact wi
   <dd>Returns an empty \{\{jsxref("Promise")\}\} that ends the presentation to the device</dd>
 </dl>
 
-
-
 ## Examples
 
 ### Creating a Non-immersive Session


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26707299/47006189-a5cdcd00-d135-11e8-8cf8-1a2752af6df7.png)

Found this markup error on the xrsession page.